### PR TITLE
fix: Replace symbols that are not equally wide with iso-width capital…

### DIFF
--- a/calendar_puzzle.c
+++ b/calendar_puzzle.c
@@ -209,7 +209,7 @@ static map_st *fill(map_st *old, int y, int x, pile_st *p)
 
 static void show_map(map_st *s)
 {
-	const char *str = " @ $ % T * X > <      ";
+	const char *str = " A B C D E F G J      ";
 	int i, j;
 
 	for (i = 3; i < 10; ++i) {


### PR DESCRIPTION
```
 $ $ @ @ T T
 $ $   @ * T
 $ $ @ @ * T T
 <   * * * > >
 < < % > > > X
 < % % X X X X
 < % %
```

```

 B B A A C C
 B B   A C C
 B B A A D C
 J J J J D D D
 E F J G G G D
 E F F F F G G
 E E E
```
make it easy to read